### PR TITLE
add toGatewayURL

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ import {
 
 export {
   detectDefaultGateway,
+  toGatewayURL,
   W3S_LINK_URL
 } from './util.js'
 

--- a/util.js
+++ b/util.js
@@ -214,6 +214,15 @@ export async function * getFromURL ({
   yield * streamToIterator(response.body)
 }
 
+export function toGatewayURL (url, gatewayBaseURL = detectDefaultGateway()) {
+  const { cid, path, type } = parseIPFSURL(url)
+
+  const relative = `/${type}/${cid}${path}`
+  const toFetch = new URL(relative, gatewayBaseURL)
+
+  return toFetch
+}
+
 export async function * getFromGateway ({
   url,
   start,
@@ -221,10 +230,7 @@ export async function * getFromGateway ({
   signal,
   gatewayURL = detectDefaultGateway()
 }) {
-  const { cid, path, type } = parseIPFSURL(url)
-
-  const relative = `/${type}/${cid}${path}`
-  const toFetch = new URL(relative, gatewayURL)
+  const toFetch = toGatewayURL(url, gatewayURL)
 
   yield * getFromURL({
     url: toFetch,


### PR DESCRIPTION
Expose toGatewayURL(url, baseGatewayURL) so that a client can resolve an IPFS URL to a fetchable https URL, using default gateway, or custom gateway